### PR TITLE
Linenumbers_filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,14 @@ jsp, lua, pascal, perl, php, powershell, python, ruby, scala, sql, swift, xml
 ```
 
 #### Installation
+
 ##### with pip
+
 ```
 pip3 install hardcodes
 ```
 ##### or build from source
+
 ```
 git clone https://github.com/s0md3v/hardcodes && cd hardcodes && python3 setup.py install
 ```
@@ -40,12 +43,14 @@ git clone https://github.com/s0md3v/hardcodes && cd hardcodes && python3 setup.p
 <hr>
 
 ### Documentation
+
 hardcodes is available as both a library as well as a command line program. The relevant documentation can be found below:
 
 - [For developers](https://github.com/s0md3v/hardcodes#for-developers)
 - [For users](https://github.com/s0md3v/hardcodes#for-users)
 
 ### For Developers
+
 The sample program below demonstrates usage of `hardcodes` library
 
 ```python
@@ -55,6 +60,7 @@ string = "console.log('hello there')"
 result = search(string, lang="common", comments="parse")
 print(result)
 ```
+
 ```python
 Output: ['hello there']
 ```
@@ -64,24 +70,29 @@ The arguments `lang` and `comments` are optional. Their use is explained below i
 <hr>
 
 ### For Users
+
 `cli.py` provides a grep-like command line interface to `hardcodes` library. You will need to install the library first to use it.
 
 #### Find strings in a file
+
 ```bash
 python cli.py /path/to/file.ext
 ```
 
 #### Find strings in a directory, recursively
+
 ```bash
 python cli.py -r /path/to/dir
 ```
 
 #### Hide paths from output
+
 ```bash
 python cli.py -o /path/to/file.ext
 ```
 
 #### Specify programming language
+
 Specifying a language is optional and should be used only when the programming language of source is already known.
 
 ```bash
@@ -89,10 +100,40 @@ python cli.py -l 'golang' /path/to/file.go
 ```
 
 #### Specify comment behaviour
-With `-c` option, you can specify 
+
+With `-c` option, you can specify
 
 - `ignore` ignore the comments completely
 - `parse`  parse the comments like code
 - `string` add comments to list of hardcoded strings
 
 `python cli.py -o /path/to/file.ext`
+
+#### Specify line numbers
+
+With the `-n`, `--line-numbers` option, you can attach the line numbers where 
+string occurred. This can be used to locate the line in code easily, or to
+use as input into a script that will modify the strings for you.
+
+The line numbers are inserted between the file name, and string, also using ':'
+as a seperator. (See 'filter' example below).
+
+#### Filter output by regular expression
+
+With the `-q`, `--query` option, the output can be filtered by applying a
+regular expression (supplied on the command line) to the extracted string.
+
+This can be used for specific tasks, such as changing all occurances of a 
+product's name, or publisher.
+
+```bash
+python cli.py -l python -n -q "source code" cli.py
+```
+
+which gives the following output:
+
+```
+cli.py:12:specify programming language of source code
+cli.py:13:include source code line numbers in output
+```
+

--- a/cli.py
+++ b/cli.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import os
+import os, re
 import argparse
 from hardcodes import search
 
@@ -10,11 +10,15 @@ parser = argparse.ArgumentParser()
 parser.add_argument('-r', '--recursive', help='use post method', dest='recursive', action='store_true')
 parser.add_argument('-c', '--comments', help='specify how to handles comments.\n\t\'ignore\'- ignore them\n\'parse\'- parse them like code\n\'string\'-return comments as hardcoded strings', dest='comments', default='parse')
 parser.add_argument('-l', '--language', help='specify programming language of source code', dest='lang', default='common')
+parser.add_argument('-n', '--line-numbers', help='include source code line numbers in output', action='store_true')
+parser.add_argument('-q', "--query", help='extract only strings matchng the regex', dest='query_match', default='')
 parser.add_argument('-o', help='don\'t show location of found strings', dest='hide_path', action='store_true')
 parser.add_argument('file', help='file', type=str)
 args = parser.parse_args()
 
 files = []
+show_line_numbers:bool = args.line_numbers
+
 if args.recursive:
     for root, dirs, l_files in os.walk(args.file):
       for file in l_files:
@@ -23,16 +27,20 @@ elif args.file:
     files.append(args.file)
 
 for file in files:
-    with open(file, 'r', encoding='utf-8') as code:
+    # with open(file, 'r', encoding='utf-8') as code:
+    with open(file, 'r') as code:
         try:
-            code = '\n'.join([line for line in code])
+            # code = '\n'.join([(line.strip()) for line in code])
+            code = '\n'.join([re.sub('\n', '', line) for line in code])
         except UnicodeDecodeError:
             continue
 
-    all_strings = search(code, args.lang, args.comments)
+    all_strings = search(code, args.lang, args.comments, show_line_numbers, args.query_match)
+    
     if args.hide_path:
         prefix = ''
     else:
         prefix = file+':'
+        
     for string in all_strings:
         print(prefix+string)

--- a/hardcodes/hardcodes.py
+++ b/hardcodes/hardcodes.py
@@ -80,7 +80,7 @@ def _tokenize(code, comments, comment_strings, containers, show_line_numbers, qu
     
     for index, char in enumerate(code):
 
-        if char == '\n':
+        if show_line_numbers and (char == '\n'):
             line_number += 1
             continue
             

--- a/hardcodes/hardcodes.py
+++ b/hardcodes/hardcodes.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import re
+
 def _gen_config(lang):
     """
     generate config for tokenization
@@ -63,7 +65,7 @@ def _if_comment_started(string, comment_strings):
             return (comment_end, len(comment_start))
 
 
-def _tokenize(code, comments, comment_strings, containers):
+def _tokenize(code, comments, comment_strings, containers, show_line_numbers, query_match):
     """
     tokenizes sources code to find hardcoded strings
     returns list of hardcoded strings
@@ -73,7 +75,15 @@ def _tokenize(code, comments, comment_strings, containers):
     skip = 0
     comment = False
     all_strings = []
+    
+    line_number = 1
+    
     for index, char in enumerate(code):
+
+        if char == '\n':
+            line_number += 1
+            continue
+            
         if skip > 0:
             skip -= 1
             continue
@@ -107,21 +117,33 @@ def _tokenize(code, comments, comment_strings, containers):
                 state = 'store'
                 container = char
             elif state == 'store' and char == container and not _is_escaped(code[:index]):
+                
                 if string:
-                    all_strings.append(string)
+                    if show_line_numbers:
+                        found_string = f"{line_number}:{string}"
+                    else:
+                        found_string = f"{string}"
+                    
+                    if query_match in ['', None]:
+                        all_strings.append( found_string )
+                    
+                    elif re.search(query_match, string):
+                        all_strings.append( found_string )
+
                 string = ''
                 state = 'look'
             else:
                 string += char
         elif state == 'store':
             string += char
+            
     return all_strings
 
 
-def search(code, lang='common', comments='parse'):
+def search(code, lang='common', comments='parse', show_line_numbers=False, query_match=''):
     """
     main function that calls other functions
     returns list of hardcoded strings
     """
     containers, comment_strings = _gen_config(lang)
-    return _tokenize(code, comments, comment_strings, containers)
+    return _tokenize(code, comments, comment_strings, containers, show_line_numbers, query_match)


### PR DESCRIPTION
I added an option to display source code line numbers associated with an extracted string, in addition to a simple regex based filter.

I have only tested under Python but if not invoked, I don't anticipate either option interfering overtly with normal execution.